### PR TITLE
Feature/echonest

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -4,3 +4,4 @@ github.com/lib/pq
 github.com/spf13/viper
 github.com/gorilla/websocket
 github.com/Sirupsen/logrus
+github.com/gorhill/cronexpr

--- a/deepmind/deepmind.go
+++ b/deepmind/deepmind.go
@@ -1,0 +1,62 @@
+package deepmind
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/thisissoon/fm-deepmind/fm"
+	"github.com/thisissoon/fm-deepmind/fm_api"
+	"github.com/thisissoon/fm-deepmind/rnd"
+	"github.com/thisissoon/fm-deepmind/socket"
+)
+
+type Config struct {
+	UserToken    string
+	EventService string
+	Secret       string
+	Db           string
+}
+
+func NewDeepmind(c Config) *Deepmind {
+	log.Printf("Creating Deepmind instance")
+	return &Deepmind{
+		config:       c,
+		eventChannel: make(chan []byte),
+		endChannel:   make(chan bool),
+		data:         fm.NewDataAdapter(c.Db),
+	}
+}
+
+type Deepmind struct {
+	config       Config
+	eventChannel chan []byte
+	endChannel   chan bool
+	data         *fm.DataAdapter
+}
+
+func (d *Deepmind) getRandomTrackUri() string {
+	genres := d.data.GetGenreDataSet(14)
+	genreIndex := rnd.Weight(genres.GetWeights())
+	genre := genres.Get(genreIndex)
+
+	tracks := d.data.GetTrackDataSetBasedOnGenre(genre.Id)
+	trackIndex := rnd.Weight(tracks.GetWeights())
+	track := tracks.Get(trackIndex)
+	return track.Id
+}
+
+func (d *Deepmind) runPerceptorListener() {
+	perceptor := socket.NewPerceptorService(
+		d.config.EventService,
+		d.config.Secret,
+		d.eventChannel)
+	go perceptor.Run()
+
+	eventHandler := socket.NewHandler(d.eventChannel, d.endChannel)
+	go eventHandler.Run()
+}
+
+func (d *Deepmind) Run() {
+	d.runPerceptorListener()
+	fmApi := fm_api.FmApiManager{Token: d.config.UserToken}
+	go fmApi.Listen(d.endChannel, 6, d.getRandomTrackUri)
+}

--- a/deepmind/deepmind.go
+++ b/deepmind/deepmind.go
@@ -2,6 +2,9 @@ package deepmind
 
 import (
 	log "github.com/Sirupsen/logrus"
+	"time"
+
+	"github.com/gorhill/cronexpr"
 
 	"github.com/thisissoon/fm-deepmind/fm"
 	"github.com/thisissoon/fm-deepmind/fm_api"
@@ -9,28 +12,39 @@ import (
 	"github.com/thisissoon/fm-deepmind/socket"
 )
 
+// return current london time
+func getLondonTime() time.Time {
+	location, _ := time.LoadLocation("Europe/London")
+	now := time.Now()
+	return now.In(location)
+}
+
 type Config struct {
 	UserToken    string
 	EventService string
 	Secret       string
 	Db           string
+	MinTracks    int // keep min number of tracks in the queue
+	LastTrackAt  int // play until
 }
 
 func NewDeepmind(c Config) *Deepmind {
 	log.Printf("Creating Deepmind instance")
 	return &Deepmind{
-		config:       c,
-		eventChannel: make(chan []byte),
-		endChannel:   make(chan bool),
-		data:         fm.NewDataAdapter(c.Db),
+		config:            c,
+		eventChannel:      make(chan []byte),
+		endChannel:        make(chan bool),
+		data:              fm.NewDataAdapter(c.Db),
+		audioSumaryMatrix: &fm.AudioSumaryMatrix{},
 	}
 }
 
 type Deepmind struct {
-	config       Config
-	eventChannel chan []byte
-	endChannel   chan bool
-	data         *fm.DataAdapter
+	config            Config
+	eventChannel      chan []byte
+	endChannel        chan bool
+	data              *fm.DataAdapter
+	audioSumaryMatrix *fm.AudioSumaryMatrix
 }
 
 func (d *Deepmind) getRandomTrackUri() string {
@@ -57,6 +71,56 @@ func (d *Deepmind) runPerceptorListener() {
 
 func (d *Deepmind) Run() {
 	d.runPerceptorListener()
+
+	// push tracks into the queue
 	fmApi := fm_api.FmApiManager{Token: d.config.UserToken}
-	go fmApi.Listen(d.endChannel, 6, d.getRandomTrackUri)
+	if false {
+		go d.Listen(fmApi, d.getRandomTrackUri)
+	}
+
+	// synchronise echonest stats
+	d.ScheduleAction(cronexpr.MustParse("* * * * * * *"), func() {
+		d.PopulateAudioSumaryMatrix()
+		log.Printf("%s", d.audioSumaryMatrix.GetQuartile(getLondonTime()))
+	})
+}
+
+func (d *Deepmind) PopulateAudioSumaryMatrix() {
+	d.audioSumaryMatrix.Populate(d.data.GetAudioSummary())
+}
+
+func (d *Deepmind) Listen(m fm_api.FmApiManager, r func() string) {
+	for {
+		<-d.endChannel
+		if getLondonTime().Hour() < d.config.LastTrackAt { // dont run after LastTrackAt
+			queue, err := m.GetQueue()
+			if err != nil {
+				log.Printf("Error when fetching queue", err)
+				continue
+			}
+
+			for i := 0; i < (d.config.MinTracks - len(queue)); i++ {
+				go m.AddTrack(r())
+			}
+		}
+	}
+}
+
+func (d *Deepmind) ScheduleAction(cron *cronexpr.Expression, f func()) {
+	go func() {
+		// Create a ticker function
+		ticker := func() *time.Ticker {
+			next := cron.Next(time.Now())
+			diff := next.Sub(time.Now())
+			log.Infof("Next Tick: %s", next.Format(time.RFC1123))
+			return time.NewTicker(diff)
+		}
+		// Run the Ticker
+		tkr := ticker()
+		for {
+			<-tkr.C
+			f()
+			tkr = ticker()
+		}
+	}()
 }

--- a/deepmind/deepmind_test.go
+++ b/deepmind/deepmind_test.go
@@ -1,0 +1,48 @@
+package deepmind
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/thisissoon/fm-deepmind/fm"
+	"github.com/thisissoon/fm-deepmind/math"
+)
+
+func TestEchonestEndorsment(t *testing.T) {
+	d := Deepmind{}
+	d.audioSummaryWeights = &fm.AudioSummaryWeights{
+		Energy:           float64(.11),
+		Liveness:         float64(.22),
+		Speechiness:      float64(.33),
+		Acousticness:     float64(.11),
+		Instrumentalness: float64(.11),
+		Valence:          float64(.11),
+		Danceability:     float64(.11),
+	}
+
+	o := fm.DataObject{
+		Label: "abc",
+		Total: 4,
+		Meta: fm.AudioSummary{
+			Energy:           float64(.2),
+			Liveness:         float64(.3),
+			Speechiness:      float64(.4),
+			Acousticness:     float64(.5),
+			Instrumentalness: float64(.6),
+			Valence:          float64(.7),
+			Danceability:     float64(.8),
+		},
+	}
+
+	q := fm.AudioSummaryQuartile{
+		Energy:           math.Quartile{.1, .2, .3},
+		Liveness:         math.Quartile{.1, .2, .3},
+		Speechiness:      math.Quartile{.1, .2, .3},
+		Acousticness:     math.Quartile{.1, .2, .3},
+		Instrumentalness: math.Quartile{.1, .2, .3},
+		Valence:          math.Quartile{.1, .2, .3},
+		Danceability:     math.Quartile{.1, .2, .3},
+	}
+
+	assert.Equal(t, 0.33, d.AudioSummaryEndorse(o, q))
+}

--- a/fm/data.go
+++ b/fm/data.go
@@ -11,53 +11,6 @@ import (
 	"time"
 )
 
-type AudioSummary struct {
-	Key              int       `json:"key",csv:"key"`
-	Tempo            float64   `json:"tempo",csv:"tempo"`
-	Energy           float64   `json:"energy",csv:"energy"`
-	Liveness         float64   `json:"liveness",csv:"liveness"`
-	AnalysisUrl      string    `json:"analysis_url",csv:"-"`
-	Speechiness      float64   `json:"speechiness",csv:"speechiness"`
-	Acousticness     float64   `json:"acousticness",csv:"acousticness"`
-	Instrumentalness float64   `json:"instrumentalness",csv:"instrumentalness"`
-	Mode             float64   `json:"mode",csv:"mode"`
-	TimeSignature    float64   `json:"time_signature",csv:"time_signature"`
-	Duration         float64   `json:"duration",csv:"duration"`
-	Loudness         float64   `json:"loudness",csv:"loudness"`
-	Valence          float64   `json:"valence",csv:"valence"`
-	Danceability     float64   `json:"danceability",csv:"danceability"`
-	Timestamp        time.Time `csv:"timestamp"`
-}
-
-type DataObject struct {
-	Id    string
-	Label string
-	Total int
-	Meta  interface{}
-}
-
-type DataSet struct {
-	D     []DataObject
-	Total int
-}
-
-func (ds *DataSet) Append(d DataObject) {
-	ds.D = append(ds.D, d)
-	ds.Total += d.Total
-}
-
-func (ds *DataSet) GetWeights() []float64 {
-	weights := []float64{}
-	for _, d := range ds.D {
-		weights = append(weights, float64(d.Total)/float64(ds.Total))
-	}
-	return weights
-}
-
-func (ds *DataSet) Get(d int) DataObject {
-	return ds.D[d]
-}
-
 type DataAdapter struct {
 	Db *sql.DB
 }

--- a/fm/data.go
+++ b/fm/data.go
@@ -3,13 +3,22 @@ package fm
 import (
 	"database/sql"
 	"encoding/json"
+	log "github.com/Sirupsen/logrus"
 	_ "github.com/lib/pq"
-	"log"
 
 	"errors"
 	"fmt"
 	"time"
 )
+
+func NewDataAdapter(u string) *DataAdapter {
+	dataAdapter := DataAdapter{}
+	log.Printf("Creating data adapter instance")
+	if err := dataAdapter.Conn(u); err != nil {
+		log.Fatal("Scan: %e", err)
+	}
+	return &dataAdapter
+}
 
 type DataAdapter struct {
 	Db *sql.DB

--- a/fm/data.go
+++ b/fm/data.go
@@ -135,9 +135,7 @@ func (d *DataAdapter) parseAudioSummary(v sql.NullString) (AudioSummary, error) 
 func (d *DataAdapter) GetAudioSummary() []AudioSummary {
 	audioSummaries := []AudioSummary{}
 
-	query := `
-		SELECT audio_summary, created
-		FROM track WHERE audio_summary is not null`
+	query := `SELECT audio_summary, created FROM track WHERE audio_summary is not null`
 	rows, err := d.Db.Query(query)
 	if err != nil {
 		log.Fatal("%e", err)

--- a/fm/data_test.go
+++ b/fm/data_test.go
@@ -11,20 +11,20 @@ func TestParseAudioSumary(t *testing.T) {
 	v := sql.NullString{
 		String: `
 			{
-				"key": 2,
-				"tempo": 149.999,
-				"energy": 0.9,
-				"liveness": 0.3,
-				"analysis_url": "h",
-				"speechiness": 0.1,
-				"acousticness": 0.7,
-				"instrumentalness": 0.9,
-				"mode": 1,
+				"key": 5,
+				"tempo": 88.088,
+				"energy": 0.4246929822221389,
+				"liveness": 0.11306411657392115,
+				"analysis_url": "",
+				"speechiness": 0.06528033930143728,
+				"acousticness": 0.32661968843315015,
+				"instrumentalness": 1.7090341899105053e-07,
+				"mode": 0,
 				"time_signature": 4,
-				"duration": 3.4,
-				"loudness": -9.3,
-				"valence": 0.22267801204461538,
-				"danceability": 0.6063510834169058
+				"duration": 284.73333,
+				"loudness": -12.406,
+				"valence": 0.5644159063204205,
+				"danceability": 0.7072561410157304
 			}
 		`,
 		Valid: true,
@@ -33,7 +33,7 @@ func TestParseAudioSumary(t *testing.T) {
 	da := DataAdapter{}
 	as, _ := da.parseAudioSummary(v)
 
-	assert.Equal(t, 149.999, as.Tempo)
+	assert.Equal(t, 88.088, as.Tempo)
 }
 
 func TestParseAudioSumaryWhenValueIsNull(t *testing.T) {

--- a/fm/data_test.go
+++ b/fm/data_test.go
@@ -1,6 +1,7 @@
 package fm
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,4 +43,57 @@ func TestSumOfWeighShouleBeZero(t *testing.T) {
 	weights := ds.GetWeights()
 
 	assert.Equal(t, float64(1), weights[0]+weights[1]+weights[2])
+}
+
+func TestParseAudioSumary(t *testing.T) {
+
+	v := sql.NullString{
+		String: `
+			{
+				"key": 2,
+				"tempo": 149.999,
+				"energy": 0.9,
+				"liveness": 0.3,
+				"analysis_url": "h",
+				"speechiness": 0.1,
+				"acousticness": 0.7,
+				"instrumentalness": 0.9,
+				"mode": 1,
+				"time_signature": 4,
+				"duration": 3.4,
+				"loudness": -9.3,
+				"valence": 0.22267801204461538,
+				"danceability": 0.6063510834169058
+			}
+		`,
+		Valid: true,
+	}
+
+	da := DataAdapter{}
+	as, _ := da.parseAudioSummary(v)
+
+	assert.Equal(t, 149.999, as.Tempo)
+}
+
+func TestParseAudioSumaryWhenValueIsNull(t *testing.T) {
+	v := sql.NullString{
+		String: `null`,
+		Valid:  true,
+	}
+
+	da := DataAdapter{}
+	as, _ := da.parseAudioSummary(v)
+
+	assert.Equal(t, float64(0), as.Tempo)
+}
+
+func TestParseAudioSumaryWhenValueIsNill(t *testing.T) {
+	v := sql.NullString{
+		Valid: false,
+	}
+
+	da := DataAdapter{}
+	as, _ := da.parseAudioSummary(v)
+
+	assert.Equal(t, float64(0), as.Tempo)
 }

--- a/fm/data_test.go
+++ b/fm/data_test.go
@@ -7,46 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDataSetAppend(t *testing.T) {
-	ds := DataSet{}
-
-	assert.Equal(t, 0, len(ds.D))
-	ds.Append(DataObject{Label: "abc", Total: 4})
-	assert.Equal(t, 1, len(ds.D))
-}
-
-func TestDatasetKeepsCorrectTotal(t *testing.T) {
-	ds := DataSet{}
-	assert.Equal(t, 0, ds.Total)
-
-	ds.Append(DataObject{Label: "abc", Total: 4})
-	assert.Equal(t, 4, ds.Total)
-
-	ds.Append(DataObject{Label: "abc", Total: 5})
-	assert.Equal(t, 9, ds.Total)
-}
-
-func TestDatasetReturnsCorrectWeights(t *testing.T) {
-	ds := DataSet{}
-	ds.Append(DataObject{Label: "abc", Total: 4})
-	ds.Append(DataObject{Label: "abc", Total: 5})
-
-	assert.Equal(t, []float64{4.0 / 9.0, 5.0 / 9.0}, ds.GetWeights())
-}
-
-func TestSumOfWeighShouleBeZero(t *testing.T) {
-	ds := DataSet{}
-	ds.Append(DataObject{Label: "abc", Total: 4})
-	ds.Append(DataObject{Label: "abc", Total: 5})
-	ds.Append(DataObject{Label: "abc", Total: 6})
-
-	weights := ds.GetWeights()
-
-	assert.Equal(t, float64(1), weights[0]+weights[1]+weights[2])
-}
-
 func TestParseAudioSumary(t *testing.T) {
-
 	v := sql.NullString{
 		String: `
 			{

--- a/fm/model.go
+++ b/fm/model.go
@@ -45,6 +45,19 @@ type AudioSummaryQuartile struct {
 	Danceability     math.Quartile
 }
 
+// Weights for AudioSumary from set of tracks
+type AudioSummaryWeights struct {
+	Tempo            float64
+	Energy           float64
+	Liveness         float64
+	Speechiness      float64
+	Acousticness     float64
+	Instrumentalness float64
+	Loudness         float64
+	Valence          float64
+	Danceability     float64
+}
+
 type DynamicList struct {
 	L []AudioSummary
 }

--- a/fm/model.go
+++ b/fm/model.go
@@ -82,11 +82,14 @@ func (ds *DataSet) Get(d int) DataObject {
 	return ds.D[d]
 }
 
-type GenreMatrix struct {
+// Holds AudioSummary objects in a weekday and hour matrix to easily pick a
+// certain AudioSummary quartile in a certain time and day
+type AudioSumaryMatrix struct {
 	M [][]AudioSummaryQuartile
 }
 
-func (m *GenreMatrix) Populate(a []AudioSummary) {
+// Populate AudioSumary matrix from list of AudioSummary objects
+func (m *AudioSumaryMatrix) Populate(a []AudioSummary) {
 	week := make([][]DynamicList, 7)
 	for i := range week {
 		week[i] = make([]DynamicList, 24)
@@ -137,4 +140,8 @@ func (m *GenreMatrix) Populate(a []AudioSummary) {
 			}
 		}
 	}
+}
+
+func (m *AudioSumaryMatrix) GetQuartile(t time.Time) AudioSummaryQuartile {
+	return m.M[t.Weekday()][t.Hour()]
 }

--- a/fm/model.go
+++ b/fm/model.go
@@ -30,6 +30,7 @@ type AudioSummary struct {
 	Valence          float64   `json:"valence",csv:"valence"`
 	Danceability     float64   `json:"danceability",csv:"danceability"`
 	Timestamp        time.Time `csv:"timestamp"`
+	IsValid          bool
 }
 
 // Quartiles of AudioSumary from set of tracks
@@ -160,7 +161,7 @@ func (ds *DataSet) CalculateWeights() {
 func (ds *DataSet) GetWeights() []float64 {
 	weights := []float64{}
 	for _, d := range ds.D {
-		weights = append(weights, d.Weight)
+		weights = append(weights, d.Weight+d.Weight*d.Endorse)
 	}
 	return weights
 }

--- a/fm/model.go
+++ b/fm/model.go
@@ -58,6 +58,39 @@ type AudioSummaryWeights struct {
 	Danceability     float64
 }
 
+func (a *AudioSummaryWeights) Populate(l []AudioSummary) {
+	a.Tempo = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Tempo
+	}))
+	a.Energy = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Energy
+	}))
+	a.Energy = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Energy
+	}))
+	a.Liveness = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Liveness
+	}))
+	a.Speechiness = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Speechiness
+	}))
+	a.Acousticness = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Acousticness
+	}))
+	a.Instrumentalness = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Instrumentalness
+	}))
+	a.Loudness = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Loudness
+	}))
+	a.Valence = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Valence
+	}))
+	a.Danceability = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
+		return v.Danceability
+	}))
+}
+
 type DynamicList struct {
 	L []AudioSummary
 }

--- a/fm/model.go
+++ b/fm/model.go
@@ -1,0 +1,140 @@
+package fm
+
+import (
+	"github.com/thisissoon/fm-deepmind/math"
+	"time"
+)
+
+func Map(vs []AudioSummary, f func(AudioSummary) float64) []float64 {
+	vsm := make([]float64, len(vs))
+	for i, v := range vs {
+		vsm[i] = f(v)
+	}
+	return vsm
+}
+
+// Raw AudioSummary object from a track
+type AudioSummary struct {
+	Key              int       `json:"key",csv:"key"`
+	Tempo            float64   `json:"tempo",csv:"tempo"`
+	Energy           float64   `json:"energy",csv:"energy"`
+	Liveness         float64   `json:"liveness",csv:"liveness"`
+	AnalysisUrl      string    `json:"analysis_url",csv:"-"`
+	Speechiness      float64   `json:"speechiness",csv:"speechiness"`
+	Acousticness     float64   `json:"acousticness",csv:"acousticness"`
+	Instrumentalness float64   `json:"instrumentalness",csv:"instrumentalness"`
+	Mode             float64   `json:"mode",csv:"mode"`
+	TimeSignature    float64   `json:"time_signature",csv:"time_signature"`
+	Duration         float64   `json:"duration",csv:"duration"`
+	Loudness         float64   `json:"loudness",csv:"loudness"`
+	Valence          float64   `json:"valence",csv:"valence"`
+	Danceability     float64   `json:"danceability",csv:"danceability"`
+	Timestamp        time.Time `csv:"timestamp"`
+}
+
+// Quartiles of AudioSumary from set of tracks
+type AudioSummaryQuartile struct {
+	Tempo            math.Quartile
+	Energy           math.Quartile
+	Liveness         math.Quartile
+	Speechiness      math.Quartile
+	Acousticness     math.Quartile
+	Instrumentalness math.Quartile
+	Loudness         math.Quartile
+	Valence          math.Quartile
+	Danceability     math.Quartile
+}
+
+type DynamicList struct {
+	L []AudioSummary
+}
+
+func (dl *DynamicList) Add(i AudioSummary) {
+	dl.L = append(dl.L, i)
+}
+
+type DataObject struct {
+	Id    string
+	Label string
+	Total int
+	Meta  interface{}
+}
+
+type DataSet struct {
+	D     []DataObject
+	Total int
+}
+
+func (ds *DataSet) Append(d DataObject) {
+	ds.D = append(ds.D, d)
+	ds.Total += d.Total
+}
+
+func (ds *DataSet) GetWeights() []float64 {
+	weights := []float64{}
+	for _, d := range ds.D {
+		weights = append(weights, float64(d.Total)/float64(ds.Total))
+	}
+	return weights
+}
+
+func (ds *DataSet) Get(d int) DataObject {
+	return ds.D[d]
+}
+
+type GenreMatrix struct {
+	M [][]AudioSummaryQuartile
+}
+
+func (m *GenreMatrix) Populate(a []AudioSummary) {
+	week := make([][]DynamicList, 7)
+	for i := range week {
+		week[i] = make([]DynamicList, 24)
+	}
+
+	for _, audioSummary := range a {
+		time := audioSummary.Timestamp
+		weekday := time.Weekday()
+		hour := time.Hour()
+		week[weekday][hour].Add(audioSummary)
+	}
+
+	m.M = make([][]AudioSummaryQuartile, 7)
+	for i := range m.M {
+		m.M[i] = make([]AudioSummaryQuartile, 24)
+	}
+
+	for w, hours := range week {
+		for h, hour := range hours {
+			m.M[w][h] = AudioSummaryQuartile{
+				Tempo: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Tempo
+				})),
+				Energy: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Energy
+				})),
+				Liveness: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Liveness
+				})),
+				Speechiness: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Speechiness
+				})),
+				Acousticness: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Acousticness
+				})),
+				Instrumentalness: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Instrumentalness
+				})),
+				Loudness: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Loudness
+				})),
+				Valence: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Valence
+				})),
+				Danceability: math.GetQuartile(Map(hour.L, func(v AudioSummary) float64 {
+					return v.Danceability
+				})),
+			}
+		}
+	}
+}

--- a/fm/model.go
+++ b/fm/model.go
@@ -89,6 +89,32 @@ func (a *AudioSummaryWeights) Populate(l []AudioSummary) {
 	a.Danceability = math.StandardDeviation(Map(l, func(v AudioSummary) float64 {
 		return v.Danceability
 	}))
+	a.normalise()
+}
+
+func (a *AudioSummaryWeights) normalise() {
+	l := []float64{
+		a.Tempo,
+		a.Energy,
+		a.Liveness,
+		a.Speechiness,
+		a.Acousticness,
+		a.Instrumentalness,
+		a.Loudness,
+		a.Valence,
+		a.Danceability,
+	}
+	s := math.Sum(l)
+
+	a.Tempo = a.Tempo / s
+	a.Energy = a.Energy / s
+	a.Liveness = a.Liveness / s
+	a.Speechiness = a.Speechiness / s
+	a.Acousticness = a.Acousticness / s
+	a.Instrumentalness = a.Instrumentalness / s
+	a.Loudness = a.Loudness / s
+	a.Valence = a.Valence / s
+	a.Danceability = a.Danceability / s
 }
 
 type DynamicList struct {

--- a/fm/model_test.go
+++ b/fm/model_test.go
@@ -281,108 +281,108 @@ func TestAudioSumaryMatrixGetNonExistingQuartile(t *testing.T) {
 
 func TestAudioSummaryWeightsPopulateTempo(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Tempo: 1},
-		AudioSummary{Tempo: 5},
+		AudioSummary{Tempo: 1, Energy: 1},
+		AudioSummary{Tempo: 5, Energy: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Tempo)
+	assert.Equal(t, float64(.8), w.Tempo)
 }
 
 func TestAudioSummaryWeightsPopulateEnergy(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Energy: 1},
-		AudioSummary{Energy: 5},
+		AudioSummary{Energy: 1, Tempo: 1},
+		AudioSummary{Energy: 5, Tempo: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Energy)
+	assert.Equal(t, float64(.8), w.Energy)
 }
 
 func TestAudioSummaryWeightsPopulateLiveness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Liveness: 1},
-		AudioSummary{Liveness: 5},
+		AudioSummary{Liveness: 1, Tempo: 1},
+		AudioSummary{Liveness: 5, Tempo: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Liveness)
+	assert.Equal(t, float64(.8), w.Liveness)
 }
 
 func TestAudioSummaryWeightsPopulateSpeechiness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Speechiness: 1},
-		AudioSummary{Speechiness: 5},
+		AudioSummary{Speechiness: 1, Tempo: 1},
+		AudioSummary{Speechiness: 5, Tempo: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Speechiness)
+	assert.Equal(t, float64(.8), w.Speechiness)
 }
 
 func TestAudioSummaryWeightsPopulateAcousticness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Acousticness: 1},
-		AudioSummary{Acousticness: 5},
+		AudioSummary{Acousticness: 1, Tempo: 1},
+		AudioSummary{Acousticness: 5, Tempo: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Acousticness)
+	assert.Equal(t, float64(.8), w.Acousticness)
 }
 
 func TestAudioSummaryWeightsPopulateInstrumentalness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Instrumentalness: 1},
-		AudioSummary{Instrumentalness: 5},
+		AudioSummary{Instrumentalness: 1, Tempo: 1},
+		AudioSummary{Instrumentalness: 5, Tempo: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Instrumentalness)
+	assert.Equal(t, float64(.8), w.Instrumentalness)
 }
 
 func TestAudioSummaryWeightsPopulateLoudness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Loudness: 1},
-		AudioSummary{Loudness: 5},
+		AudioSummary{Loudness: 1, Tempo: 1},
+		AudioSummary{Loudness: 5, Tempo: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Loudness)
+	assert.Equal(t, float64(.8), w.Loudness)
 }
 
 func TestAudioSummaryWeightsPopulateValence(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Valence: 1},
-		AudioSummary{Valence: 5},
+		AudioSummary{Valence: 1, Tempo: 1},
+		AudioSummary{Valence: 5, Tempo: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Valence)
+	assert.Equal(t, float64(.8), w.Valence)
 }
 
 func TestAudioSummaryWeightsPopulateDanceability(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Danceability: 1},
-		AudioSummary{Danceability: 5},
+		AudioSummary{Danceability: 1, Tempo: 1},
+		AudioSummary{Danceability: 5, Tempo: 3},
 	}
 
 	w := AudioSummaryWeights{}
 	w.Populate(a)
 
-	assert.Equal(t, float64(4), w.Danceability)
+	assert.Equal(t, float64(.8), w.Danceability)
 }

--- a/fm/model_test.go
+++ b/fm/model_test.go
@@ -1,0 +1,246 @@
+package fm
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/thisissoon/fm-deepmind/math"
+	"testing"
+	"time"
+)
+
+func TestDataSetAppend(t *testing.T) {
+	ds := DataSet{}
+
+	assert.Equal(t, 0, len(ds.D))
+	ds.Append(DataObject{Label: "abc", Total: 4})
+	assert.Equal(t, 1, len(ds.D))
+}
+
+func TestDatasetKeepsCorrectTotal(t *testing.T) {
+	ds := DataSet{}
+	assert.Equal(t, 0, ds.Total)
+
+	ds.Append(DataObject{Label: "abc", Total: 4})
+	assert.Equal(t, 4, ds.Total)
+
+	ds.Append(DataObject{Label: "abc", Total: 5})
+	assert.Equal(t, 9, ds.Total)
+}
+
+func TestDatasetReturnsCorrectWeights(t *testing.T) {
+	ds := DataSet{}
+	ds.Append(DataObject{Label: "abc", Total: 4})
+	ds.Append(DataObject{Label: "abc", Total: 5})
+
+	assert.Equal(t, []float64{4.0 / 9.0, 5.0 / 9.0}, ds.GetWeights())
+}
+
+func TestSumOfWeighShouleBeZero(t *testing.T) {
+	ds := DataSet{}
+	ds.Append(DataObject{Label: "abc", Total: 4})
+	ds.Append(DataObject{Label: "abc", Total: 5})
+	ds.Append(DataObject{Label: "abc", Total: 6})
+
+	weights := ds.GetWeights()
+
+	assert.Equal(t, float64(1), weights[0]+weights[1]+weights[2])
+}
+
+func TestGenreMatrixTempoMediam(t *testing.T) {
+	gm := GenreMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp: time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Tempo:     0.1,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Tempo:     0.3,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Tempo:     0.4,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Tempo:     0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Tempo)
+}
+
+func TestGenreMatrixLivenessMediam(t *testing.T) {
+	gm := GenreMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp: time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Liveness:  0.1,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Liveness:  0.3,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Liveness:  0.4,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Liveness:  0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Liveness)
+}
+
+func TestGenreMatrixSpeechinessMediam(t *testing.T) {
+	gm := GenreMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp:   time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Speechiness: 0.1,
+		},
+		AudioSummary{
+			Timestamp:   time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Speechiness: 0.3,
+		},
+		AudioSummary{
+			Timestamp:   time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Speechiness: 0.4,
+		},
+		AudioSummary{
+			Timestamp:   time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Speechiness: 0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Speechiness)
+}
+
+func TestGenreMatrixAcousticnessMediam(t *testing.T) {
+	gm := GenreMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Acousticness: 0.1,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Acousticness: 0.3,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Acousticness: 0.4,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Acousticness: 0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Acousticness)
+}
+
+func TestGenreMatrixInstrumentalnessMediam(t *testing.T) {
+	gm := GenreMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp:        time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Instrumentalness: 0.1,
+		},
+		AudioSummary{
+			Timestamp:        time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Instrumentalness: 0.3,
+		},
+		AudioSummary{
+			Timestamp:        time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Instrumentalness: 0.4,
+		},
+		AudioSummary{
+			Timestamp:        time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Instrumentalness: 0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Instrumentalness)
+}
+
+func TestGenreMatrixLoudnessMediam(t *testing.T) {
+	gm := GenreMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp: time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Loudness:  0.1,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Loudness:  0.3,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Loudness:  0.4,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Loudness:  0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Loudness)
+}
+
+func TestGenreMatrixValenceMediam(t *testing.T) {
+	gm := GenreMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp: time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Valence:   0.1,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Valence:   0.3,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Valence:   0.4,
+		},
+		AudioSummary{
+			Timestamp: time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Valence:   0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Valence)
+}
+
+func TestGenreMatrixDanceabilityMediam(t *testing.T) {
+	gm := GenreMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Danceability: 0.1,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Danceability: 0.3,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Danceability: 0.4,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Danceability: 0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Danceability)
+}

--- a/fm/model_test.go
+++ b/fm/model_test.go
@@ -45,8 +45,8 @@ func TestSumOfWeighShouleBeZero(t *testing.T) {
 	assert.Equal(t, float64(1), weights[0]+weights[1]+weights[2])
 }
 
-func TestGenreMatrixTempoMediam(t *testing.T) {
-	gm := GenreMatrix{}
+func TestAudioSumaryMatrixTempoMediam(t *testing.T) {
+	gm := AudioSumaryMatrix{}
 
 	audioSummaries := []AudioSummary{
 		AudioSummary{
@@ -70,8 +70,8 @@ func TestGenreMatrixTempoMediam(t *testing.T) {
 	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Tempo)
 }
 
-func TestGenreMatrixLivenessMediam(t *testing.T) {
-	gm := GenreMatrix{}
+func TestAudioSumaryMatrixLivenessMediam(t *testing.T) {
+	gm := AudioSumaryMatrix{}
 
 	audioSummaries := []AudioSummary{
 		AudioSummary{
@@ -95,8 +95,8 @@ func TestGenreMatrixLivenessMediam(t *testing.T) {
 	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Liveness)
 }
 
-func TestGenreMatrixSpeechinessMediam(t *testing.T) {
-	gm := GenreMatrix{}
+func TestAudioSumaryMatrixSpeechinessMediam(t *testing.T) {
+	gm := AudioSumaryMatrix{}
 
 	audioSummaries := []AudioSummary{
 		AudioSummary{
@@ -120,8 +120,8 @@ func TestGenreMatrixSpeechinessMediam(t *testing.T) {
 	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Speechiness)
 }
 
-func TestGenreMatrixAcousticnessMediam(t *testing.T) {
-	gm := GenreMatrix{}
+func TestAudioSumaryMatrixAcousticnessMediam(t *testing.T) {
+	gm := AudioSumaryMatrix{}
 
 	audioSummaries := []AudioSummary{
 		AudioSummary{
@@ -145,8 +145,8 @@ func TestGenreMatrixAcousticnessMediam(t *testing.T) {
 	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Acousticness)
 }
 
-func TestGenreMatrixInstrumentalnessMediam(t *testing.T) {
-	gm := GenreMatrix{}
+func TestAudioSumaryMatrixInstrumentalnessMediam(t *testing.T) {
+	gm := AudioSumaryMatrix{}
 
 	audioSummaries := []AudioSummary{
 		AudioSummary{
@@ -170,8 +170,8 @@ func TestGenreMatrixInstrumentalnessMediam(t *testing.T) {
 	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Instrumentalness)
 }
 
-func TestGenreMatrixLoudnessMediam(t *testing.T) {
-	gm := GenreMatrix{}
+func TestAudioSumaryMatrixLoudnessMediam(t *testing.T) {
+	gm := AudioSumaryMatrix{}
 
 	audioSummaries := []AudioSummary{
 		AudioSummary{
@@ -195,8 +195,8 @@ func TestGenreMatrixLoudnessMediam(t *testing.T) {
 	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Loudness)
 }
 
-func TestGenreMatrixValenceMediam(t *testing.T) {
-	gm := GenreMatrix{}
+func TestAudioSumaryMatrixValenceMediam(t *testing.T) {
+	gm := AudioSumaryMatrix{}
 
 	audioSummaries := []AudioSummary{
 		AudioSummary{
@@ -220,8 +220,8 @@ func TestGenreMatrixValenceMediam(t *testing.T) {
 	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Valence)
 }
 
-func TestGenreMatrixDanceabilityMediam(t *testing.T) {
-	gm := GenreMatrix{}
+func TestAudioSumaryMatrixDanceabilityMediam(t *testing.T) {
+	gm := AudioSumaryMatrix{}
 
 	audioSummaries := []AudioSummary{
 		AudioSummary{
@@ -243,4 +243,38 @@ func TestGenreMatrixDanceabilityMediam(t *testing.T) {
 	}
 	gm.Populate(audioSummaries)
 	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), gm.M[1][8].Danceability)
+}
+
+func TestAudioSumaryMatrixGetExistingQuartile(t *testing.T) {
+	gm := AudioSumaryMatrix{}
+
+	audioSummaries := []AudioSummary{
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.April, 25, 8, 0, 0, 0, time.UTC),
+			Danceability: 0.1,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.April, 25, 8, 30, 0, 0, time.UTC),
+			Danceability: 0.3,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.May, 25, 9, 0, 0, 0, time.UTC),
+			Danceability: 0.4,
+		},
+		AudioSummary{
+			Timestamp:    time.Date(2016, time.May, 3, 8, 0, 0, 0, time.UTC),
+			Danceability: 0.4,
+		},
+	}
+	gm.Populate(audioSummaries)
+	quartile := gm.GetQuartile(time.Date(2016, time.April, 25, 8, 15, 0, 0, time.UTC))
+	assert.Equal(t, math.GetQuartile([]float64{0.1, 0.3}), quartile.Danceability)
+}
+
+func TestAudioSumaryMatrixGetNonExistingQuartile(t *testing.T) {
+	gm := AudioSumaryMatrix{}
+	gm.Populate([]AudioSummary{})
+
+	quartile := gm.GetQuartile(time.Now())
+	assert.Equal(t, math.Quartile{0, 0, 0}, quartile.Danceability)
 }

--- a/fm/model_test.go
+++ b/fm/model_test.go
@@ -45,6 +45,20 @@ func TestSumOfWeighShouleBeZero(t *testing.T) {
 	assert.Equal(t, float64(1), weights[0]+weights[1]+weights[2])
 }
 
+func TestEndorse(t *testing.T) {
+	ds := DataSet{}
+	ds.Append(DataObject{Label: "abc", Total: 4})
+	ds.Append(DataObject{Label: "abc", Total: 5})
+	ds.Append(DataObject{Label: "abc", Total: 6})
+	ds.Endorse(func(ds DataObject) float64 {
+		return float64(ds.Total * 2)
+	})
+
+	assert.Equal(t, float64(8), ds.D[0].Endorse)
+	assert.Equal(t, float64(10), ds.D[1].Endorse)
+	assert.Equal(t, float64(12), ds.D[2].Endorse)
+}
+
 func TestAudioSumaryMatrixTempoMediam(t *testing.T) {
 	gm := AudioSumaryMatrix{}
 
@@ -279,22 +293,10 @@ func TestAudioSumaryMatrixGetNonExistingQuartile(t *testing.T) {
 	assert.Equal(t, math.Quartile{0, 0, 0}, quartile.Danceability)
 }
 
-func TestAudioSummaryWeightsPopulateTempo(t *testing.T) {
-	a := []AudioSummary{
-		AudioSummary{Tempo: 1, Energy: 1},
-		AudioSummary{Tempo: 5, Energy: 3},
-	}
-
-	w := AudioSummaryWeights{}
-	w.Populate(a)
-
-	assert.Equal(t, float64(.8), w.Tempo)
-}
-
 func TestAudioSummaryWeightsPopulateEnergy(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Energy: 1, Tempo: 1},
-		AudioSummary{Energy: 5, Tempo: 3},
+		AudioSummary{Energy: 1, Liveness: 1},
+		AudioSummary{Energy: 5, Liveness: 3},
 	}
 
 	w := AudioSummaryWeights{}
@@ -305,8 +307,8 @@ func TestAudioSummaryWeightsPopulateEnergy(t *testing.T) {
 
 func TestAudioSummaryWeightsPopulateLiveness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Liveness: 1, Tempo: 1},
-		AudioSummary{Liveness: 5, Tempo: 3},
+		AudioSummary{Liveness: 1, Speechiness: 1},
+		AudioSummary{Liveness: 5, Speechiness: 3},
 	}
 
 	w := AudioSummaryWeights{}
@@ -317,8 +319,8 @@ func TestAudioSummaryWeightsPopulateLiveness(t *testing.T) {
 
 func TestAudioSummaryWeightsPopulateSpeechiness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Speechiness: 1, Tempo: 1},
-		AudioSummary{Speechiness: 5, Tempo: 3},
+		AudioSummary{Speechiness: 1, Liveness: 1},
+		AudioSummary{Speechiness: 5, Liveness: 3},
 	}
 
 	w := AudioSummaryWeights{}
@@ -329,8 +331,8 @@ func TestAudioSummaryWeightsPopulateSpeechiness(t *testing.T) {
 
 func TestAudioSummaryWeightsPopulateAcousticness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Acousticness: 1, Tempo: 1},
-		AudioSummary{Acousticness: 5, Tempo: 3},
+		AudioSummary{Acousticness: 1, Liveness: 1},
+		AudioSummary{Acousticness: 5, Liveness: 3},
 	}
 
 	w := AudioSummaryWeights{}
@@ -341,8 +343,8 @@ func TestAudioSummaryWeightsPopulateAcousticness(t *testing.T) {
 
 func TestAudioSummaryWeightsPopulateInstrumentalness(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Instrumentalness: 1, Tempo: 1},
-		AudioSummary{Instrumentalness: 5, Tempo: 3},
+		AudioSummary{Instrumentalness: 1, Liveness: 1},
+		AudioSummary{Instrumentalness: 5, Liveness: 3},
 	}
 
 	w := AudioSummaryWeights{}
@@ -351,22 +353,10 @@ func TestAudioSummaryWeightsPopulateInstrumentalness(t *testing.T) {
 	assert.Equal(t, float64(.8), w.Instrumentalness)
 }
 
-func TestAudioSummaryWeightsPopulateLoudness(t *testing.T) {
-	a := []AudioSummary{
-		AudioSummary{Loudness: 1, Tempo: 1},
-		AudioSummary{Loudness: 5, Tempo: 3},
-	}
-
-	w := AudioSummaryWeights{}
-	w.Populate(a)
-
-	assert.Equal(t, float64(.8), w.Loudness)
-}
-
 func TestAudioSummaryWeightsPopulateValence(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Valence: 1, Tempo: 1},
-		AudioSummary{Valence: 5, Tempo: 3},
+		AudioSummary{Valence: 1, Instrumentalness: 1},
+		AudioSummary{Valence: 5, Instrumentalness: 3},
 	}
 
 	w := AudioSummaryWeights{}
@@ -377,8 +367,8 @@ func TestAudioSummaryWeightsPopulateValence(t *testing.T) {
 
 func TestAudioSummaryWeightsPopulateDanceability(t *testing.T) {
 	a := []AudioSummary{
-		AudioSummary{Danceability: 1, Tempo: 1},
-		AudioSummary{Danceability: 5, Tempo: 3},
+		AudioSummary{Danceability: 1, Instrumentalness: 1},
+		AudioSummary{Danceability: 5, Instrumentalness: 3},
 	}
 
 	w := AudioSummaryWeights{}

--- a/fm/model_test.go
+++ b/fm/model_test.go
@@ -278,3 +278,111 @@ func TestAudioSumaryMatrixGetNonExistingQuartile(t *testing.T) {
 	quartile := gm.GetQuartile(time.Now())
 	assert.Equal(t, math.Quartile{0, 0, 0}, quartile.Danceability)
 }
+
+func TestAudioSummaryWeightsPopulateTempo(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Tempo: 1},
+		AudioSummary{Tempo: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Tempo)
+}
+
+func TestAudioSummaryWeightsPopulateEnergy(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Energy: 1},
+		AudioSummary{Energy: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Energy)
+}
+
+func TestAudioSummaryWeightsPopulateLiveness(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Liveness: 1},
+		AudioSummary{Liveness: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Liveness)
+}
+
+func TestAudioSummaryWeightsPopulateSpeechiness(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Speechiness: 1},
+		AudioSummary{Speechiness: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Speechiness)
+}
+
+func TestAudioSummaryWeightsPopulateAcousticness(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Acousticness: 1},
+		AudioSummary{Acousticness: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Acousticness)
+}
+
+func TestAudioSummaryWeightsPopulateInstrumentalness(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Instrumentalness: 1},
+		AudioSummary{Instrumentalness: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Instrumentalness)
+}
+
+func TestAudioSummaryWeightsPopulateLoudness(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Loudness: 1},
+		AudioSummary{Loudness: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Loudness)
+}
+
+func TestAudioSummaryWeightsPopulateValence(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Valence: 1},
+		AudioSummary{Valence: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Valence)
+}
+
+func TestAudioSummaryWeightsPopulateDanceability(t *testing.T) {
+	a := []AudioSummary{
+		AudioSummary{Danceability: 1},
+		AudioSummary{Danceability: 5},
+	}
+
+	w := AudioSummaryWeights{}
+	w.Populate(a)
+
+	assert.Equal(t, float64(4), w.Danceability)
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ func main() {
 	viper.SetDefault("EVENT_SERVICE", "")
 	viper.SetDefault("SECRET", "")
 	viper.SetDefault("DB", "")
+	viper.SetDefault("MIN_TRACKS", 2)
+	viper.SetDefault("LAST_TRACK_AT", 18)
 
 	deepmind := deepmind.NewDeepmind(
 		deepmind.Config{
@@ -23,8 +25,11 @@ func main() {
 			EventService: viper.GetString("EVENT_SERVICE"),
 			Secret:       viper.GetString("SECRET"),
 			Db:           viper.GetString("DB"),
+			MinTracks:    viper.GetInt("MIN_TRACKS"),
+			LastTrackAt:  viper.GetInt("LAST_TRACK_AT"),
 		},
 	)
+
 	deepmind.Run()
 
 	signals := make(chan os.Signal, 1)

--- a/main.go
+++ b/main.go
@@ -5,56 +5,27 @@ import (
 	"os/signal"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/thisissoon/fm-deepmind/fm"
-	"github.com/thisissoon/fm-deepmind/fm_api"
-	"github.com/thisissoon/fm-deepmind/rnd"
-
 	"github.com/spf13/viper"
-	"github.com/thisissoon/fm-deepmind/socket"
+
+	"github.com/thisissoon/fm-deepmind/deepmind"
 )
 
 func main() {
 	viper.AutomaticEnv()
 	viper.SetDefault("USER_TOKEN", "")
-	viper.SetDefault("PERCEPTOR_ADDRESS", "perceptor.thisissoon.fm")
+	viper.SetDefault("EVENT_SERVICE", "")
 	viper.SetDefault("SECRET", "")
 	viper.SetDefault("DB", "")
 
-	log.Printf("%s", viper.GetString("PERCEPTOR_ADDRESS"))
-
-	eventChannel := make(chan []byte)
-	endChannel := make(chan bool)
-
-	perceptor := socket.NewPerceptorService(
-		viper.GetString("PERCEPTOR_ADDRESS"),
-		viper.GetString("SECRET"),
-		eventChannel)
-	go perceptor.Run()
-
-	eventHandler := socket.NewHandler(eventChannel, endChannel)
-	go eventHandler.Run()
-
-	fmApi := fm_api.FmApiManager{
-		Token: viper.GetString("USER_TOKEN"),
-	}
-
-	data := fm.DataAdapter{}
-	if err := data.Conn(viper.GetString("DB")); err != nil {
-		log.Fatal("Scan: %e", err)
-		return
-	}
-
-	anon := func() string {
-		genres := data.GetGenreDataSet(14)
-		genreIndex := rnd.Weight(genres.GetWeights())
-		d := genres.Get(genreIndex)
-
-		tracks := data.GetTrackDataSetBasedOnGenre(d.Id)
-		trackIndex := rnd.Weight(tracks.GetWeights())
-		track := tracks.Get(trackIndex)
-		return track.Id
-	}
-	go fmApi.Listen(endChannel, 2, anon)
+	deepmind := deepmind.NewDeepmind(
+		deepmind.Config{
+			UserToken:    viper.GetString("USER_TOKEN"),
+			EventService: viper.GetString("EVENT_SERVICE"),
+			Secret:       viper.GetString("SECRET"),
+			Db:           viper.GetString("DB"),
+		},
+	)
+	deepmind.Run()
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, os.Kill)

--- a/math/stats.go
+++ b/math/stats.go
@@ -61,6 +61,14 @@ func Average(l []float64) float64 {
 	return total / float64(len(l))
 }
 
+func Sum(l []float64) float64 {
+	sum := float64(0)
+	for _, v := range l {
+		sum += v
+	}
+	return sum
+}
+
 func SumSq(l []float64) float64 {
 	sum := float64(0)
 	for _, v := range l {

--- a/math/stats.go
+++ b/math/stats.go
@@ -54,7 +54,7 @@ func GetQuartile(l []float64) Quartile {
 }
 
 func Average(l []float64) float64 {
-	total := 0.0
+	total := float64(0)
 	for _, v := range l {
 		total += v
 	}

--- a/math/stats.go
+++ b/math/stats.go
@@ -1,0 +1,46 @@
+package math
+
+import (
+	"math"
+	"sort"
+)
+
+type Quartile struct {
+	First  float64
+	Second float64
+	Third  float64
+}
+
+func (q *Quartile) HasIn(f float64) bool {
+	return q.First <= f && f <= q.Third
+}
+
+func Median(l []float64) float64 {
+	sort.Float64s(l)
+	lenght := float64(len(l))
+	isOdd := math.Mod(lenght, float64(2)) == 1
+	if isOdd {
+		return l[int(lenght/2)]
+	}
+
+	middle := lenght / float64(2)
+	return (l[int(middle-1)] + l[int(middle)]) / 2
+}
+
+func GetQuartile(l []float64) Quartile {
+	sort.Float64s(l)
+
+	lenght := float64(len(l))
+	isOdd := math.Mod(lenght, float64(2)) == 1
+
+	middle := int(lenght / 2)
+	q := Quartile{Second: Median(l)}
+	if isOdd {
+		q.First = Median(l[:middle])
+		q.Third = Median(l[middle:])
+	} else {
+		q.First = Median(l[:middle])
+		q.Third = Median(l[middle:])
+	}
+	return q
+}

--- a/math/stats.go
+++ b/math/stats.go
@@ -16,6 +16,14 @@ func (q *Quartile) HasIn(f float64) bool {
 }
 
 func Median(l []float64) float64 {
+	switch len(l) {
+	case 0:
+		return 0
+	case 1:
+		return l[0]
+	case 2:
+		return (l[0] + l[1]) / 2
+	}
 	sort.Float64s(l)
 	lenght := float64(len(l))
 	isOdd := math.Mod(lenght, float64(2)) == 1

--- a/math/stats.go
+++ b/math/stats.go
@@ -52,3 +52,24 @@ func GetQuartile(l []float64) Quartile {
 	}
 	return q
 }
+
+func Average(l []float64) float64 {
+	total := 0.0
+	for _, v := range l {
+		total += v
+	}
+	return total / float64(len(l))
+}
+
+func SumSq(l []float64) float64 {
+	sum := float64(0)
+	for _, v := range l {
+		sum += v * v
+	}
+	return sum
+}
+
+func StandardDeviation(l []float64) float64 {
+	avg := Average(l)
+	return SumSq(l)/float64(len(l)) - avg*avg
+}

--- a/math/stats_test.go
+++ b/math/stats_test.go
@@ -1,0 +1,47 @@
+package math
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMedianOddLenghOfList(t *testing.T) {
+	l := []float64{2, 1, 6, 3, 8}
+	assert.Equal(t, float64(3), Median(l))
+}
+
+func TestMedianEvenLenghOfList(t *testing.T) {
+	l := []float64{3, 1, 7, 5}
+	assert.Equal(t, float64(4), Median(l))
+}
+
+func TestGetQuartileEvenLength(t *testing.T) {
+	l := []float64{15, 36, 7, 41, 39, 40}
+
+	q := GetQuartile(l)
+	assert.Equal(t, float64(15), q.First)
+	assert.Equal(t, float64(37.5), q.Second)
+	assert.Equal(t, float64(40), q.Third)
+}
+
+func TestGetQuartileOddLength(t *testing.T) {
+	l := []float64{36, 7, 6, 15, 39, 41, 40, 49, 42, 47, 43}
+
+	q := GetQuartile(l)
+	assert.Equal(t, float64(15), q.First)
+	assert.Equal(t, float64(40), q.Second)
+	assert.Equal(t, float64(42.5), q.Third)
+}
+
+func TestQuartileHasNotIn(t *testing.T) {
+	q := Quartile{First: 0, Third: 10}
+
+	assert.Equal(t, true, q.HasIn(5))
+}
+
+func TestQuartileHasIn(t *testing.T) {
+	q := Quartile{First: 0, Third: 10}
+
+	assert.Equal(t, false, q.HasIn(15))
+}

--- a/math/stats_test.go
+++ b/math/stats_test.go
@@ -45,3 +45,31 @@ func TestQuartileHasIn(t *testing.T) {
 
 	assert.Equal(t, false, q.HasIn(15))
 }
+
+func TestStandardDeviationDifferentNumbersInSet(t *testing.T) {
+	l := []float64{1, 2, 3, 4, 5, 6, 7}
+	o := StandardDeviation(l)
+
+	assert.Equal(t, float64(4), o)
+}
+
+func TestStandardDeviationSameNumbersInSet(t *testing.T) {
+	l := []float64{1, 1, 1, 1, 1}
+	o := StandardDeviation(l)
+
+	assert.Equal(t, float64(0), o)
+}
+
+func TestAverage(t *testing.T) {
+	l := []float64{1, 2, 3, 4, 5, 6, 7}
+	a := Average(l)
+
+	assert.Equal(t, float64(4), a)
+}
+
+func TestSumSq(t *testing.T) {
+	l := []float64{1, 2, 3, 4, 5, 6, 7}
+	a := SumSq(l)
+
+	assert.Equal(t, float64(140), a)
+}

--- a/socket/connect.go
+++ b/socket/connect.go
@@ -72,6 +72,7 @@ func (p *PerceptorService) headers() http.Header {
 
 // Creates a new PerceptorService
 func NewPerceptorService(addr string, secret string, channel chan []byte) *PerceptorService {
+	log.Printf("Creating event listener instance")
 	return &PerceptorService{
 		channel: channel,
 		addr:    addr,


### PR DESCRIPTION
Deepmind keeps echonest stats in memory in 2 dimensional matrix - rows are days and columns hours. Each cell contains a quartiles of echonest property. This matrix is synchronised when deepminds gets run and once per month. 

`audioSummaryWeights` store normalised standard deviation calculated from echonest stats. This matrix is updated every day because characteristic of audio summary weights changes every day. The list define a weight of audio summary fields. Tempo is almost same during the day so tempo doesn't affect weight of tracks much but danceability usually changes a lot during a day. So weight of danceability of track has higher values. Those weights are summarised when track in between 1st and 2nd quartiles in particular day and hour. The sum is saved to endorse field of a track.

All tracks are endorsed based on criteria above and  endorse value changes weight of the track so the change of picking a track matching audio stats is higher. 
